### PR TITLE
[Feat] 컬러 에셋 추가 (#4)

### DIFF
--- a/OverTheRainbow/OverTheRainbow/Assets.xcassets/backgroundColor.colorset/Contents.json
+++ b/OverTheRainbow/OverTheRainbow/Assets.xcassets/backgroundColor.colorset/Contents.json
@@ -1,0 +1,41 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE9",
+          "green" : "0xF4",
+          "red" : "0xF4"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE9",
+          "green" : "0xF4",
+          "red" : "0xF4"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
+  }
+}

--- a/OverTheRainbow/OverTheRainbow/Assets.xcassets/boxBarColor.colorset/Contents.json
+++ b/OverTheRainbow/OverTheRainbow/Assets.xcassets/boxBarColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC1",
+          "green" : "0xDF",
+          "red" : "0xDF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC1",
+          "green" : "0xDF",
+          "red" : "0xDF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/OverTheRainbow/OverTheRainbow/Assets.xcassets/heavenLetterBackgroundCOlor.colorset/Contents.json
+++ b/OverTheRainbow/OverTheRainbow/Assets.xcassets/heavenLetterBackgroundCOlor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF3",
+          "green" : "0xEC",
+          "red" : "0xD3"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF3",
+          "green" : "0xEC",
+          "red" : "0xD3"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/OverTheRainbow/OverTheRainbow/Assets.xcassets/heavenNavigationBarColor.colorset/Contents.json
+++ b/OverTheRainbow/OverTheRainbow/Assets.xcassets/heavenNavigationBarColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.940",
+          "blue" : "0xF0",
+          "green" : "0xE8",
+          "red" : "0xCD"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.940",
+          "blue" : "0xF0",
+          "green" : "0xE8",
+          "red" : "0xCD"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/OverTheRainbow/OverTheRainbow/Assets.xcassets/letterBackgroundColor.colorset/Contents.json
+++ b/OverTheRainbow/OverTheRainbow/Assets.xcassets/letterBackgroundColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC7",
+          "green" : "0xE3",
+          "red" : "0xE3"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC7",
+          "green" : "0xE3",
+          "red" : "0xE3"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/OverTheRainbow/OverTheRainbow/Assets.xcassets/letterBodyTextColor.colorset/Contents.json
+++ b/OverTheRainbow/OverTheRainbow/Assets.xcassets/letterBodyTextColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x46",
+          "green" : "0x49",
+          "red" : "0x49"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x46",
+          "green" : "0x49",
+          "red" : "0x49"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/OverTheRainbow/OverTheRainbow/Assets.xcassets/letterHeadTextColor.colorset/Contents.json
+++ b/OverTheRainbow/OverTheRainbow/Assets.xcassets/letterHeadTextColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2F",
+          "green" : "0x31",
+          "red" : "0x31"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2F",
+          "green" : "0x31",
+          "red" : "0x31"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/OverTheRainbow/OverTheRainbow/Assets.xcassets/navigationBarColor.colorset/Contents.json
+++ b/OverTheRainbow/OverTheRainbow/Assets.xcassets/navigationBarColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.940",
+          "blue" : "0xE9",
+          "green" : "0xF4",
+          "red" : "0xF4"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.940",
+          "blue" : "0xE9",
+          "green" : "0xF4",
+          "red" : "0xF4"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/OverTheRainbow/OverTheRainbow/Assets.xcassets/settingCategoryTextColor.colorset/Contents.json
+++ b/OverTheRainbow/OverTheRainbow/Assets.xcassets/settingCategoryTextColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x8A",
+          "green" : "0x7D",
+          "red" : "0x7F"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x8A",
+          "green" : "0x7D",
+          "red" : "0x7F"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/OverTheRainbow/OverTheRainbow/Assets.xcassets/textColor.colorset/Contents.json
+++ b/OverTheRainbow/OverTheRainbow/Assets.xcassets/textColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x41",
+          "green" : "0x41",
+          "red" : "0x4A"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x41",
+          "green" : "0x41",
+          "red" : "0x4A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/OverTheRainbow/OverTheRainbow/Assets.xcassets/whiteColor.colorset/Contents.json
+++ b/OverTheRainbow/OverTheRainbow/Assets.xcassets/whiteColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFA",
+          "green" : "0xFA",
+          "red" : "0xFA"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFA",
+          "green" : "0xFA",
+          "red" : "0xFA"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## 관련 이슈
#4 공용 컬레 에셋 추가

## 작업 내용
- [x] 11개의 색 추가
![image](https://user-images.githubusercontent.com/18394923/179454678-f2dcb8a8-2866-4836-bafc-fe6729a18754.png)

## 리뷰 포인트
- 컬러명을 변경한 부분이 있습니다. 괜찮은지 피드백 바랍니다. 
  - accentColor -> boxBarColor : AccentColor는 따로 쓰이는 곳이 있는 것 같아 변경했습니다. 
  - letterColor -> letterBackgroundColor: letter 뜻에 "글자"도 있어서, 몇 달 후에 코드를 볼 때 헷갈릴 수도 있을 것 같아 변경해봤습니다. 
- 추가한 컬러가 있습니다. 피드백 바랍니다. 
  - 네비게이션바의 색상이 기본 배경색과 약간 달라서 navigationBarColor 으로 추가했습니다. 
  - 천국뷰 편지 배경색과 네비게이션 바 색을 추가했습니다. 
    - 각각 heavenLetterBackgroundColor, heavenNavigationBarColor 라고 붙였습니다. 
<img width="704" alt="image" src="https://user-images.githubusercontent.com/18394923/179454773-d3413f17-ce01-40a1-914e-7350852f9ea3.png">


## Reference

[컬러 정리 노션 링크](https://imminent-maxilla-071.notion.site/d78dda9291434d92afc1e4bdf17befae)

[iOS 커스텀 컬러 관리 방식(블로그)](https://wodyios.tistory.com/11)
