### PR TITLE
[Feat] 설정뷰 구현 (#25)

### DIFF
--- a/OverTheRainbow/OverTheRainbow.xcodeproj/project.pbxproj
+++ b/OverTheRainbow/OverTheRainbow.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		27C8AC23288542CD000D2374 /* LetterListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C8AC22288542CD000D2374 /* LetterListViewController.swift */; };
-		27C8AC25288542DC000D2374 /* TempFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C8AC24288542DC000D2374 /* TempFile.swift */; };
 		2C93A74F2887E5FA005A0CA8 /* SettingView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2C93A74E2887E5FA005A0CA8 /* SettingView.storyboard */; };
 		2C93A7512887E609005A0CA8 /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C93A7502887E609005A0CA8 /* SettingViewController.swift */; };
 		2C93A7532888068B005A0CA8 /* UpdatePetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C93A7522888068B005A0CA8 /* UpdatePetViewController.swift */; };
@@ -65,7 +64,6 @@
 /* Begin PBXFileReference section */
 		0306C05ACD039E0A7DFC5789 /* Pods_OverTheRainbow.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OverTheRainbow.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		27C8AC22288542CD000D2374 /* LetterListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterListViewController.swift; sourceTree = "<group>"; };
-		27C8AC24288542DC000D2374 /* TempFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempFile.swift; sourceTree = "<group>"; };
 		2C93A74E2887E5FA005A0CA8 /* SettingView.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SettingView.storyboard; sourceTree = "<group>"; };
 		2C93A7502887E609005A0CA8 /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
 		2C93A7522888068B005A0CA8 /* UpdatePetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePetViewController.swift; sourceTree = "<group>"; };
@@ -584,7 +582,6 @@
 				A8509B892888D0E400CD88C1 /* FlowerLogStatus.swift in Sources */,
 				C56CDAC6287EE41E00C1F5F9 /* SceneDelegate.swift in Sources */,
 				2C93A7532888068B005A0CA8 /* UpdatePetViewController.swift in Sources */,
-				27C8AC25288542DC000D2374 /* TempFile.swift in Sources */,
 				2C93A7512887E609005A0CA8 /* SettingViewController.swift in Sources */,
 				A8509B80288827CD00CD88C1 /* PetInputDto.swift in Sources */,
 				A8509B8B2888D79800CD88C1 /* LetterResultDto.swift in Sources */,

--- a/OverTheRainbow/OverTheRainbow.xcodeproj/project.pbxproj
+++ b/OverTheRainbow/OverTheRainbow.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		27C8AC23288542CD000D2374 /* LetterListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C8AC22288542CD000D2374 /* LetterListViewController.swift */; };
 		27C8AC25288542DC000D2374 /* TempFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C8AC24288542DC000D2374 /* TempFile.swift */; };
+		2C93A74F2887E5FA005A0CA8 /* SettingView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2C93A74E2887E5FA005A0CA8 /* SettingView.storyboard */; };
+		2C93A7512887E609005A0CA8 /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C93A7502887E609005A0CA8 /* SettingViewController.swift */; };
+		2C93A7532888068B005A0CA8 /* UpdatePetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C93A7522888068B005A0CA8 /* UpdatePetViewController.swift */; };
 		C56CDAC4287EE41E00C1F5F9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56CDAC3287EE41E00C1F5F9 /* AppDelegate.swift */; };
 		C56CDAC6287EE41E00C1F5F9 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56CDAC5287EE41E00C1F5F9 /* SceneDelegate.swift */; };
 		C56CDAC8287EE41E00C1F5F9 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56CDAC7287EE41E00C1F5F9 /* ViewController.swift */; };
@@ -20,6 +23,9 @@
 /* Begin PBXFileReference section */
 		27C8AC22288542CD000D2374 /* LetterListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterListViewController.swift; sourceTree = "<group>"; };
 		27C8AC24288542DC000D2374 /* TempFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempFile.swift; sourceTree = "<group>"; };
+		2C93A74E2887E5FA005A0CA8 /* SettingView.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SettingView.storyboard; sourceTree = "<group>"; };
+		2C93A7502887E609005A0CA8 /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
+		2C93A7522888068B005A0CA8 /* UpdatePetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePetViewController.swift; sourceTree = "<group>"; };
 		C56CDAC0287EE41E00C1F5F9 /* OverTheRainbow.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OverTheRainbow.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C56CDAC3287EE41E00C1F5F9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C56CDAC5287EE41E00C1F5F9 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -52,6 +58,7 @@
 		27C8AC1F28854156000D2374 /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				2C93A74D2887E5EA005A0CA8 /* SettingView */,
 				27C8AC21288542B1000D2374 /* letterList */,
 			);
 			path = Screens;
@@ -71,6 +78,16 @@
 				27C8AC22288542CD000D2374 /* LetterListViewController.swift */,
 			);
 			path = letterList;
+			sourceTree = "<group>";
+		};
+		2C93A74D2887E5EA005A0CA8 /* SettingView */ = {
+			isa = PBXGroup;
+			children = (
+				2C93A74E2887E5FA005A0CA8 /* SettingView.storyboard */,
+				2C93A7502887E609005A0CA8 /* SettingViewController.swift */,
+				2C93A7522888068B005A0CA8 /* UpdatePetViewController.swift */,
+			);
+			path = SettingView;
 			sourceTree = "<group>";
 		};
 		C56CDAB7287EE41E00C1F5F9 = {
@@ -166,6 +183,7 @@
 			files = (
 				C56CDAD0287EE41F00C1F5F9 /* LaunchScreen.storyboard in Resources */,
 				C56CDACD287EE41F00C1F5F9 /* Assets.xcassets in Resources */,
+				2C93A74F2887E5FA005A0CA8 /* SettingView.storyboard in Resources */,
 				C56CDACB287EE41E00C1F5F9 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -202,7 +220,9 @@
 				C56CDAC8287EE41E00C1F5F9 /* ViewController.swift in Sources */,
 				C56CDAC4287EE41E00C1F5F9 /* AppDelegate.swift in Sources */,
 				C56CDAC6287EE41E00C1F5F9 /* SceneDelegate.swift in Sources */,
+				2C93A7532888068B005A0CA8 /* UpdatePetViewController.swift in Sources */,
 				27C8AC25288542DC000D2374 /* TempFile.swift in Sources */,
+				2C93A7512887E609005A0CA8 /* SettingViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OverTheRainbow/OverTheRainbow/Base.lproj/Main.storyboard
+++ b/OverTheRainbow/OverTheRainbow/Base.lproj/Main.storyboard
@@ -1,24 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="OverTheRainbow" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="60.869565217391312" y="105.80357142857143"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/OverTheRainbow/OverTheRainbow/DataAccess/Realm/RealmConfig.swift
+++ b/OverTheRainbow/OverTheRainbow/DataAccess/Realm/RealmConfig.swift
@@ -12,8 +12,8 @@ import RealmSwift
 class RealmConfig: DataAccessConfig {
     public static let config = RealmConfig()
     
-    private let realm: Realm = try! Realm()
-    
+    private let realm: Realm
+
     private func getRepository() -> RealmRepository {
         return RealmRepository(realm: self.realm)
     }
@@ -22,5 +22,8 @@ class RealmConfig: DataAccessConfig {
         return RealmService(realm, self.getRepository())
     }
     
-    private init() {}
+    private init() {
+        realm = try! Realm()
+        print(realm.configuration.fileURL!)
+    }
 }

--- a/OverTheRainbow/OverTheRainbow/Info.plist
+++ b/OverTheRainbow/OverTheRainbow/Info.plist
@@ -16,7 +16,7 @@
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 					<key>UISceneStoryboardFile</key>
-					<string>Main</string>
+					<string>SettingView</string>
 				</dict>
 			</array>
 		</dict>

--- a/OverTheRainbow/OverTheRainbow/Screens/SettingView/SettingView.storyboard
+++ b/OverTheRainbow/OverTheRainbow/Screens/SettingView/SettingView.storyboard
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Image references" minToolsVersion="12.0"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--SettingView-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="SettingView" title="SettingView" id="Y6W-OH-hqX" customClass="SettingViewController" customModule="OverTheRainbow" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4De-Ug-WOs">
+                                <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                                <color key="barTintColor" name="navigationBarColor"/>
+                                <imageReference key="backIndicatorImage" image="chevron.backward" catalog="system" symbolScale="default"/>
+                                <items>
+                                    <navigationItem title="아이 정보" id="u8P-gq-gPr"/>
+                                </items>
+                            </navigationBar>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="아이 정보" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6mH-9q-ebg">
+                                <rect key="frame" x="40" y="148" width="67" height="21.5"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                <color key="textColor" name="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="체중" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qjj-Wl-nru">
+                                <rect key="frame" x="40" y="386" width="32" height="21.5"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                <color key="textColor" name="settingCategoryTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="종" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A47-jG-CeF">
+                                <rect key="frame" x="40" y="273" width="16" height="21.5"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                <color key="textColor" name="settingCategoryTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이름" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E6D-yc-sAl">
+                                <rect key="frame" x="40" y="216.5" width="31.5" height="21.5"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                <color key="textColor" name="settingCategoryTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="생일" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OjC-Vo-UCz">
+                                <rect key="frame" x="40" y="329.5" width="32" height="21.5"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                <color key="textColor" name="settingCategoryTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Q1-Ac-xf6">
+                                <rect key="frame" x="37" y="179.5" width="340" height="2"/>
+                                <color key="backgroundColor" name="letterBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="340" id="AIf-8Y-J8A"/>
+                                    <constraint firstAttribute="height" constant="2" id="mag-jw-FTN"/>
+                                </constraints>
+                            </view>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="또또" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q3G-Uh-DrB">
+                                <rect key="frame" x="161" y="216" width="201" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                <color key="textColor" name="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="강아지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rkj-sH-Q4V">
+                                <rect key="frame" x="161" y="273" width="201" height="22"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                <color key="textColor" name="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="2222년 2월 2일" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jN0-dA-P3J">
+                                <rect key="frame" x="161" y="329" width="121" height="22"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                <color key="textColor" name="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="7kg" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LZd-KV-yHZ">
+                                <rect key="frame" x="161" y="386" width="201" height="22"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                <color key="textColor" name="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" name="backgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="6mH-9q-ebg" firstAttribute="top" secondItem="4De-Ug-WOs" secondAttribute="bottom" constant="60" id="0VS-Te-MSC"/>
+                            <constraint firstItem="A47-jG-CeF" firstAttribute="top" secondItem="E6D-yc-sAl" secondAttribute="bottom" constant="35" id="4RP-AQ-7ys"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="9Q1-Ac-xf6" secondAttribute="trailing" constant="17" id="71b-4O-tJL"/>
+                            <constraint firstItem="E6D-yc-sAl" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="40" id="7Fu-ub-5y3"/>
+                            <constraint firstItem="A47-jG-CeF" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="40" id="C47-N0-gRn"/>
+                            <constraint firstItem="qjj-Wl-nru" firstAttribute="top" secondItem="OjC-Vo-UCz" secondAttribute="bottom" constant="35" id="D5S-Hg-B0p"/>
+                            <constraint firstItem="qjj-Wl-nru" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="40" id="DTj-RE-CX2"/>
+                            <constraint firstItem="OjC-Vo-UCz" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="40" id="INq-8F-EzE"/>
+                            <constraint firstItem="4De-Ug-WOs" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="QH5-ea-ki1"/>
+                            <constraint firstItem="4De-Ug-WOs" firstAttribute="leading" secondItem="5EZ-qb-Rvc" secondAttribute="leading" id="SZp-yS-Ses"/>
+                            <constraint firstItem="4De-Ug-WOs" firstAttribute="centerX" secondItem="9Q1-Ac-xf6" secondAttribute="centerX" id="XMU-U0-gzc"/>
+                            <constraint firstItem="E6D-yc-sAl" firstAttribute="top" secondItem="9Q1-Ac-xf6" secondAttribute="bottom" constant="35" id="YE3-Bt-vox"/>
+                            <constraint firstItem="OjC-Vo-UCz" firstAttribute="top" secondItem="A47-jG-CeF" secondAttribute="bottom" constant="35" id="YJh-eL-VfY"/>
+                            <constraint firstItem="6mH-9q-ebg" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="40" id="cFK-Bl-Quz"/>
+                            <constraint firstItem="9Q1-Ac-xf6" firstAttribute="leading" secondItem="5EZ-qb-Rvc" secondAttribute="leadingMargin" constant="17" id="jtF-ML-WHV"/>
+                            <constraint firstItem="9Q1-Ac-xf6" firstAttribute="top" secondItem="6mH-9q-ebg" secondAttribute="bottom" constant="10" id="qeM-Bo-9K9"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="birthLabel" destination="jN0-dA-P3J" id="CKV-bd-xht"/>
+                        <outlet property="nameLabel" destination="q3G-Uh-DrB" id="9h8-7V-210"/>
+                        <outlet property="navigationBar" destination="u8P-gq-gPr" id="47g-CT-fUd"/>
+                        <outlet property="speciesLabel" destination="Rkj-sH-Q4V" id="gJ9-gy-dwQ"/>
+                        <outlet property="weightLabel" destination="LZd-KV-yHZ" id="Nt0-wt-rXC"/>
+                        <segue destination="hJC-uI-0Bd" kind="presentation" identifier="UpdatePetView" id="dO6-q6-yM3"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="137.68115942028987" y="105.80357142857143"/>
+        </scene>
+        <!--Update Pet View Controller-->
+        <scene sceneID="Z9J-DW-pbf">
+            <objects>
+                <viewController storyboardIdentifier="UpdatePetView" id="hJC-uI-0Bd" customClass="UpdatePetViewController" customModule="OverTheRainbow" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="oe9-UM-mNi">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fYK-Sq-Rae">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                <color key="barTintColor" name="navigationBarColor"/>
+                                <items>
+                                    <navigationItem title="정보 수정" id="pl9-ny-nOI"/>
+                                </items>
+                            </navigationBar>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="체중" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cAx-eY-meV">
+                                <rect key="frame" x="59" y="305" width="32" height="21.5"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                <color key="textColor" name="settingCategoryTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="종" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I50-yH-sx0">
+                                <rect key="frame" x="59" y="192" width="16" height="21.5"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                <color key="textColor" name="settingCategoryTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="이름" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DPN-d8-Yi9">
+                                <rect key="frame" x="59" y="135" width="32" height="22"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                <color key="textColor" name="settingCategoryTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="생일" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qDk-N9-hIB">
+                                <rect key="frame" x="59" y="248" width="32" height="21.5"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
+                                <color key="textColor" name="settingCategoryTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="J9e-9v-c7U">
+                                <rect key="frame" x="160" y="129" width="200" height="34"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Ygq-fY-Bhc">
+                                <rect key="frame" x="160" y="185" width="200" height="34"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="tln-RC-W0E">
+                                <rect key="frame" x="160" y="241" width="200" height="34"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="r9k-SH-MfI">
+                                <rect key="frame" x="160" y="298" width="200" height="34"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="4lt-IQ-0FL"/>
+                        <color key="backgroundColor" name="backgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="wRM-mf-oXf"/>
+                    <connections>
+                        <outlet property="birthTextField" destination="tln-RC-W0E" id="rmB-cP-Ynf"/>
+                        <outlet property="nameTextField" destination="J9e-9v-c7U" id="3Ez-us-zD0"/>
+                        <outlet property="navigationBar" destination="pl9-ny-nOI" id="qmG-jD-vDR"/>
+                        <outlet property="speciesTextField" destination="Ygq-fY-Bhc" id="Hy5-Co-hiO"/>
+                        <outlet property="weightTextField" destination="r9k-SH-MfI" id="eAG-bu-cvW"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="wVH-2f-DWw" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="995.65217391304361" y="105.80357142857143"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="chevron.backward" catalog="system" width="96" height="128"/>
+        <namedColor name="backgroundColor">
+            <color red="0.95686274509803926" green="0.95686274509803926" blue="0.9137254901960784" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="letterBackgroundColor">
+            <color red="0.8901960784313725" green="0.8901960784313725" blue="0.7803921568627451" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="navigationBarColor">
+            <color red="0.95686274509803926" green="0.95686274509803926" blue="0.9137254901960784" alpha="0.93999999761581421" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="settingCategoryTextColor">
+            <color red="0.49803921568627452" green="0.49019607843137253" blue="0.54117647058823526" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="textColor">
+            <color red="0.29019607843137257" green="0.25490196078431371" blue="0.25490196078431371" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/OverTheRainbow/OverTheRainbow/Screens/SettingView/SettingViewController.swift
+++ b/OverTheRainbow/OverTheRainbow/Screens/SettingView/SettingViewController.swift
@@ -1,0 +1,52 @@
+//
+//  SettingViewController.swift
+//  OverTheRainbow
+//
+//  Created by 김승창 on 2022/07/20.
+//
+
+import UIKit
+
+class SettingViewController: UIViewController {
+
+    @IBOutlet weak var navigationBar: UINavigationItem!
+    @IBOutlet weak var nameLabel: UILabel!
+    @IBOutlet weak var speciesLabel: UILabel!
+    @IBOutlet weak var birthLabel: UILabel!
+    @IBOutlet weak var weightLabel: UILabel!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let updateButton = UIBarButtonItem(barButtonSystemItem: .edit, target: self, action: #selector(updatePet))
+        updateButton.tintColor = UIColor(named: "textColor")
+        navigationBar.rightBarButtonItem = updateButton
+    }
+
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        let destinationVC = segue.destination as? UpdatePetViewController
+        destinationVC!.delegate = self
+    }
+
+    @objc func updatePet() {
+        print("Update pet")
+        performSegue(withIdentifier: "UpdatePetView", sender: self)
+    }
+}
+
+extension SettingViewController: SendBackDelegate {
+    func dataReceived(data: Pet) {
+        nameLabel.text = data.name
+        speciesLabel.text = data.species
+        birthLabel.text = data.birth
+        weightLabel.text = data.weight
+    }
+}
+
+// MARK: - Mock Data
+struct Pet {
+    var name: String
+    var species: String
+    var birth: String
+    var weight: String
+}

--- a/OverTheRainbow/OverTheRainbow/Screens/SettingView/SettingViewController.swift
+++ b/OverTheRainbow/OverTheRainbow/Screens/SettingView/SettingViewController.swift
@@ -15,17 +15,29 @@ class SettingViewController: UIViewController {
     @IBOutlet weak var birthLabel: UILabel!
     @IBOutlet weak var weightLabel: UILabel!
 
+    let service: DataAccessService = DataAccessProvider.dataAccessConfig.getService()
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
         let updateButton = UIBarButtonItem(barButtonSystemItem: .edit, target: self, action: #selector(updatePet))
         updateButton.tintColor = UIColor(named: "textColor")
         navigationBar.rightBarButtonItem = updateButton
+
+        do {
+            let petDTO = try service.findPet(id: "62e0952349d71adbcea8ae97")
+            nameLabel.text = petDTO.name
+            speciesLabel.text = petDTO.species
+            birthLabel.text = String(petDTO.age)
+            weightLabel.text = String(petDTO.weight)
+        } catch {
+            print("Error finding pet : \(error)")
+        }
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        let destinationVC = segue.destination as? UpdatePetViewController
-        destinationVC!.delegate = self
+//        let destinationVC = segue.destination as? UpdatePetViewController
+//        destinationVC!.delegate = self
     }
 
     @objc func updatePet() {
@@ -34,19 +46,19 @@ class SettingViewController: UIViewController {
     }
 }
 
-extension SettingViewController: SendBackDelegate {
-    func dataReceived(data: Pet) {
-        nameLabel.text = data.name
-        speciesLabel.text = data.species
-        birthLabel.text = data.birth
-        weightLabel.text = data.weight
-    }
-}
-
-// MARK: - Mock Data
-struct Pet {
-    var name: String
-    var species: String
-    var birth: String
-    var weight: String
-}
+//extension SettingViewController: SendBackDelegate {
+//    func dataReceived(data: Pet) {
+//        nameLabel.text = data.name
+//        speciesLabel.text = data.species
+//        birthLabel.text = data.birth
+//        weightLabel.text = data.weight
+//    }
+//}
+//
+//// MARK: - Mock Data
+//struct Pet {
+//    var name: String
+//    var species: String
+//    var birth: String
+//    var weight: String
+//}

--- a/OverTheRainbow/OverTheRainbow/Screens/SettingView/UpdatePetViewController.swift
+++ b/OverTheRainbow/OverTheRainbow/Screens/SettingView/UpdatePetViewController.swift
@@ -1,0 +1,51 @@
+//
+//  UpdatePetViewController.swift
+//  OverTheRainbow
+//
+//  Created by 김승창 on 2022/07/20.
+//
+
+import UIKit
+
+protocol SendBackDelegate {
+    func dataReceived(data: Pet)
+}
+
+class UpdatePetViewController: UIViewController {
+
+    @IBOutlet weak var navigationBar: UINavigationItem!
+
+    @IBOutlet weak var nameTextField: UITextField!
+    @IBOutlet weak var speciesTextField: UITextField!
+    @IBOutlet weak var birthTextField: UITextField!
+    @IBOutlet weak var weightTextField: UITextField!
+
+    var delegate: SendBackDelegate?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelBtnPressed))
+        let confirmButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(confirmBtnPressed))
+        cancelButton.tintColor = UIColor(named: "textColor")
+        confirmButton.tintColor = UIColor(named: "textColor")
+
+        navigationBar.leftBarButtonItem = cancelButton
+        navigationBar.rightBarButtonItem = confirmButton
+    }
+
+    @objc func cancelBtnPressed() {
+        self.dismiss(animated: true)
+    }
+
+    @objc func confirmBtnPressed() {
+        // todo: Pet Model 업데이트
+        print("confirm")
+
+        if let name = nameTextField.text, let species = speciesTextField.text, let birth = birthTextField.text, let weight = weightTextField.text {
+            let myPet = Pet(name: name, species: species, birth: birth, weight: weight)
+            delegate?.dataReceived(data: myPet)
+        }
+        self.dismiss(animated: true)
+    }
+}

--- a/OverTheRainbow/OverTheRainbow/Screens/SettingView/UpdatePetViewController.swift
+++ b/OverTheRainbow/OverTheRainbow/Screens/SettingView/UpdatePetViewController.swift
@@ -43,8 +43,8 @@ class UpdatePetViewController: UIViewController {
         print("confirm")
 
         if let name = nameTextField.text, let species = speciesTextField.text, let birth = birthTextField.text, let weight = weightTextField.text {
-            let myPet = Pet(name: name, species: species, birth: birth, weight: weight)
-            delegate?.dataReceived(data: myPet)
+//            let myPet = Pet(name: name, species: species, birth: birth, weight: weight)
+//            delegate?.dataReceived(data: myPet)
         }
         self.dismiss(animated: true)
     }


### PR DESCRIPTION
## 개요 
(#25 )설정뷰를 구현하였습니다.

## 작업 내용
- 설정뷰 구현

## 스크린샷
<p align="left">
<img src="https://user-images.githubusercontent.com/88371913/179963696-44024d12-e20a-474f-a5b4-ee07e82c8831.png" width=250>
<img src="https://user-images.githubusercontent.com/88371913/179963704-0ee2a807-d6e3-4586-9906-31e8b4c20053.png" width=250>
<img src="https://user-images.githubusercontent.com/88371913/179963711-cec9e174-5df8-43f0-9ff6-7cb210aa7ddc.png" width=250>
</p>

## 주의 사항 
- Pet 데이터 모델을 임시로 정의했습니다.
- 수정 페이지에서 dismiss시 설정 페이지의 프로퍼티들이 바뀌도록 delegate를 사용하였습니다. (Realm이 들어오면 수정뷰에서는 Realm에 수정사항을 저장하고 dismiss되었을 시 데이터를 다시 읽어오도록 변경하면 됩니다.)
- 수정 사항들에 대하여 입력을 받을 때 적절한 컴포넌트를 사용하도록 변경해야 합니다. (생일, 체중)

## Reference
[ViewController간 데이터 교환하기](https://macinjune.com/all-posts/web-developing/swift/xcode-swift-viewcontroller간-데이터-교환하기/)