### PR TITLE
[Feat] 천국뷰 편지 리스트 뷰 구현

### DIFF
--- a/OverTheRainbow/OverTheRainbow.xcodeproj/project.pbxproj
+++ b/OverTheRainbow/OverTheRainbow.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		27C8AC23288542CD000D2374 /* LetterListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C8AC22288542CD000D2374 /* LetterListViewController.swift */; };
 		27C8AC25288542DC000D2374 /* TempFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C8AC24288542DC000D2374 /* TempFile.swift */; };
+		2C93A7562888171F005A0CA8 /* HeavenLetterList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2C93A7552888171F005A0CA8 /* HeavenLetterList.storyboard */; };
+		2C93A75828881731005A0CA8 /* HeavenLetterListTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C93A75728881731005A0CA8 /* HeavenLetterListTableViewController.swift */; };
 		C56CDAC4287EE41E00C1F5F9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56CDAC3287EE41E00C1F5F9 /* AppDelegate.swift */; };
 		C56CDAC6287EE41E00C1F5F9 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56CDAC5287EE41E00C1F5F9 /* SceneDelegate.swift */; };
 		C56CDAC8287EE41E00C1F5F9 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56CDAC7287EE41E00C1F5F9 /* ViewController.swift */; };
@@ -20,6 +22,8 @@
 /* Begin PBXFileReference section */
 		27C8AC22288542CD000D2374 /* LetterListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterListViewController.swift; sourceTree = "<group>"; };
 		27C8AC24288542DC000D2374 /* TempFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempFile.swift; sourceTree = "<group>"; };
+		2C93A7552888171F005A0CA8 /* HeavenLetterList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = HeavenLetterList.storyboard; sourceTree = "<group>"; };
+		2C93A75728881731005A0CA8 /* HeavenLetterListTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeavenLetterListTableViewController.swift; sourceTree = "<group>"; };
 		C56CDAC0287EE41E00C1F5F9 /* OverTheRainbow.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OverTheRainbow.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C56CDAC3287EE41E00C1F5F9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C56CDAC5287EE41E00C1F5F9 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -52,6 +56,7 @@
 		27C8AC1F28854156000D2374 /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				2C93A75428881700005A0CA8 /* HeavenView */,
 				27C8AC21288542B1000D2374 /* letterList */,
 			);
 			path = Screens;
@@ -71,6 +76,15 @@
 				27C8AC22288542CD000D2374 /* LetterListViewController.swift */,
 			);
 			path = letterList;
+			sourceTree = "<group>";
+		};
+		2C93A75428881700005A0CA8 /* HeavenView */ = {
+			isa = PBXGroup;
+			children = (
+				2C93A7552888171F005A0CA8 /* HeavenLetterList.storyboard */,
+				2C93A75728881731005A0CA8 /* HeavenLetterListTableViewController.swift */,
+			);
+			path = HeavenView;
 			sourceTree = "<group>";
 		};
 		C56CDAB7287EE41E00C1F5F9 = {
@@ -165,6 +179,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C56CDAD0287EE41F00C1F5F9 /* LaunchScreen.storyboard in Resources */,
+				2C93A7562888171F005A0CA8 /* HeavenLetterList.storyboard in Resources */,
 				C56CDACD287EE41F00C1F5F9 /* Assets.xcassets in Resources */,
 				C56CDACB287EE41E00C1F5F9 /* Main.storyboard in Resources */,
 			);
@@ -198,6 +213,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2C93A75828881731005A0CA8 /* HeavenLetterListTableViewController.swift in Sources */,
 				27C8AC23288542CD000D2374 /* LetterListViewController.swift in Sources */,
 				C56CDAC8287EE41E00C1F5F9 /* ViewController.swift in Sources */,
 				C56CDAC4287EE41E00C1F5F9 /* AppDelegate.swift in Sources */,

--- a/OverTheRainbow/OverTheRainbow/Screens/HeavenView/HeavenLetterList.storyboard
+++ b/OverTheRainbow/OverTheRainbow/Screens/HeavenView/HeavenLetterList.storyboard
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="bmT-38-EFF">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Heaven Letter List Table View Controller-->
+        <scene sceneID="1JM-UG-oLJ">
+            <objects>
+                <tableViewController storyboardIdentifier="HeavenLetterList" id="bmT-38-EFF" customClass="HeavenLetterListTableViewController" customModule="OverTheRainbow" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="BGh-I9-qI2">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" name="heavenLetterBackgroundColor"/>
+                        <navigationBar key="tableHeaderView" contentMode="scaleToFill" id="ddz-ZK-1gH">
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                            <color key="barTintColor" name="heavenNavigationBarColor"/>
+                            <items>
+                                <navigationItem title="Title" id="seQ-5W-77p"/>
+                            </items>
+                        </navigationBar>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="Letter" id="kHc-wh-LKi">
+                                <rect key="frame" x="0.0" y="88.5" width="414" height="43.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="kHc-wh-LKi" id="e7W-eg-LXy">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableViewCellContentView>
+                                <color key="backgroundColor" name="heavenLetterBackgroundColor"/>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="bmT-38-EFF" id="UGO-Mw-JdW"/>
+                            <outlet property="delegate" destination="bmT-38-EFF" id="jMU-XN-5EZ"/>
+                        </connections>
+                    </tableView>
+                    <connections>
+                        <outlet property="navigationBar" destination="seQ-5W-77p" id="Be8-w9-Mkm"/>
+                    </connections>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Kfa-EX-PeO" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="364" y="104"/>
+        </scene>
+    </scenes>
+    <resources>
+        <namedColor name="heavenLetterBackgroundColor">
+            <color red="0.82745098039215681" green="0.92549019607843142" blue="0.95294117647058818" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="heavenNavigationBarColor">
+            <color red="0.80392156862745101" green="0.90980392156862744" blue="0.94117647058823528" alpha="0.93999999761581421" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/OverTheRainbow/OverTheRainbow/Screens/HeavenView/HeavenLetterListTableViewController.swift
+++ b/OverTheRainbow/OverTheRainbow/Screens/HeavenView/HeavenLetterListTableViewController.swift
@@ -1,0 +1,187 @@
+//
+//  HeavenLetterListTableViewController.swift
+//  OverTheRainbow
+//
+//  Created by 김승창 on 2022/07/20.
+//
+
+import UIKit
+
+class HeavenLetterListTableViewController: UITableViewController {
+
+    @IBOutlet weak var navigationBar: UINavigationItem!
+    var letters: [Letter]?
+    var titleButton = UIButton(type: .custom)
+    var monthPickerView = UIPickerView()
+    var toolBar = UIToolbar()
+    let yearList = ["2003년", "2004년", "2005년", "2006년", "2007년", "2008년", "2009년", "2010년", "2011년", "2012년", "2013년", "2014년", "2015년", "2016년", "2017년", "2018년", "2019년", "2020년", "2021년", "2022년"]
+    let monthList = ["1월", "2월", "3월", "4월", "5월", "6월", "7월", "8월", "9월", "10월", "11월", "12월"]
+    var selectedYear = ""
+    var selectedMonth = ""
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let currentDate = Date()
+        var formatter: DateFormatter {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy년 M월"
+            return formatter
+        }
+        let yearAndMonth = formatter.string(from: currentDate).components(separatedBy: " ")
+        selectedYear = yearAndMonth[0]
+        selectedMonth = yearAndMonth[1]
+
+        loadLetters(year: selectedYear, month: selectedMonth)
+        setTitleButton(title: selectedMonth)
+    }
+
+    func setTitleButton(title: String) {
+        let imageAttachment = NSTextAttachment()
+        imageAttachment.image = UIImage(systemName: "chevron.down")?.withTintColor(.black)
+        let fullString = NSMutableAttributedString(string: "\(title) ")
+        fullString.append(NSAttributedString(attachment: imageAttachment))
+
+        titleButton.setAttributedTitle(fullString, for: .normal)
+        titleButton.frame = CGRect(x: 0, y: 0, width: 50, height: 0)
+        titleButton.setTitleColor(.black, for: .normal)
+        titleButton.addTarget(self, action: #selector(self.chooseDate), for: .touchUpInside)
+
+        navigationBar.title = title
+        navigationBar.titleView = titleButton
+    }
+
+    func loadLetters(year: String, month: String) {
+        letters = mockLetters.filter {
+            $0.year == year && $0.month == month
+        }.sorted { $0.year == $1.year ? $0.month < $1.month : $0.year < $1.year }
+    }
+
+    // MARK: - Table view data source
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return letters?.count ?? 1
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "Letter", for: indexPath)
+
+        if let letter = letters?[indexPath.row] {
+            cell.textLabel?.text = letter.title
+        } else {
+            cell.textLabel?.text = "No letter."
+        }
+
+        return cell
+    }
+
+//    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+//        let destinationVC = segue.destination as? LetterDetailViewController
+//
+//        if let indexPath = tableView.indexPathForSelectedRow {
+//            destinationVC.selectedLetter = letters?[indexPath.row]
+//        }
+//    }
+}
+
+// MARK: - UIPicker
+extension HeavenLetterListTableViewController: UIPickerViewDataSource, UIPickerViewDelegate {
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 2
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        if component == 0 {
+            return yearList.count
+        } else {
+            return monthList.count
+        }
+    }
+
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        if component == 0 {
+            return yearList[row]
+        } else {
+            return monthList[row]
+        }
+    }
+
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        selectedYear = yearList[monthPickerView.selectedRow(inComponent: 0)]
+        selectedMonth = monthList[monthPickerView.selectedRow(inComponent: 1)]
+
+        print("\(selectedYear) \(selectedMonth) selected!")
+    }
+
+    @objc func chooseDate() {
+
+        titleButton.isEnabled = false
+
+        monthPickerView = UIPickerView.init()
+        monthPickerView.dataSource = self
+        monthPickerView.delegate = self
+        monthPickerView.contentMode = .center
+        monthPickerView.backgroundColor = .systemGray6
+        monthPickerView.selectRow(yearList.firstIndex(of: selectedYear)!, inComponent: 0, animated: true)
+        monthPickerView.selectRow(monthList.firstIndex(of: selectedMonth)!, inComponent: 1, animated: true)
+
+        self.view.addSubview(self.monthPickerView)
+
+        let flexSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+
+        let done = UIBarButtonItem()
+        done.title = "확인"
+        done.tintColor = .black
+        done.style = .done
+        done.target = self
+        done.action = #selector(onDoneButtonTapped)
+        toolBar = UIToolbar.init()
+
+        monthPickerView.frame = CGRect(x: 0, y: UIScreen.main.bounds.height - 1080, width: UIScreen.main.bounds.width, height: 250)
+
+        UIView.animate(withDuration: 0.5) {
+            self.monthPickerView.frame = CGRect(x: 0, y: UIScreen.main.bounds.height - 850, width: UIScreen.main.bounds.width, height: 250)
+            self.toolBar.frame = CGRect(x: 0.0, y: UIScreen.main.bounds.size.height - 600, width: UIScreen.main.bounds.size.width, height: 45)
+        }
+
+        toolBar.barTintColor = .systemGray6
+        toolBar.isTranslucent = true
+        toolBar.setItems([flexSpace, done, flexSpace], animated: true)
+        self.view.addSubview(toolBar)
+    }
+
+    @objc func onDoneButtonTapped() {
+
+        titleButton.isEnabled = true
+        setTitleButton(title: selectedMonth)
+        loadLetters(year: selectedYear, month: selectedMonth)
+        tableView.reloadData()
+        UIView.animate(withDuration: 0.5) {
+            self.monthPickerView.frame = CGRect(x: 0, y: UIScreen.main.bounds.height - 1200, width: UIScreen.main.bounds.width, height: 250)
+            self.toolBar.frame = CGRect(x: 0.0, y: UIScreen.main.bounds.size.height - 1000, width: UIScreen.main.bounds.size.width, height: 45)
+        } completion: { _ in
+            self.toolBar.removeFromSuperview()
+            self.monthPickerView.removeFromSuperview()
+        }
+    }
+}
+
+// MARK: - Letter Model
+struct Letter {
+    var title: String
+    var content: String
+    var year: String
+    var month: String
+}
+
+var mockLetters: [Letter] = [
+    Letter(title: "1번", content: "1번 편지 내용입니다.", year: "2000년", month: "1월"),
+    Letter(title: "2번", content: "2번 편지 내용입니다.", year: "2001년", month: "2월"),
+    Letter(title: "3번", content: "3번 편지 내용입니다.", year: "2002년", month: "3월"),
+    Letter(title: "4번", content: "4번 편지 내용입니다.", year: "2003년", month: "4월"),
+    Letter(title: "5번", content: "5번 편지 내용입니다.", year: "2004년", month: "5월"),
+    Letter(title: "6번", content: "6번 편지 내용입니다.", year: "2005년", month: "6월"),
+    Letter(title: "7번", content: "7번 편지 내용입니다.", year: "2006년", month: "7월"),
+    Letter(title: "8번", content: "8번 편지 내용입니다.", year: "2007년", month: "8월"),
+    Letter(title: "9번", content: "9번 편지 내용입니다.", year: "2008년", month: "9월"),
+    Letter(title: "10번", content: "10번 편지 내용입니다.", year: "2022년", month: "7월")
+]


### PR DESCRIPTION
## 개요 
(#23 ) 천국뷰에서 편지 리스트를 보는 뷰를 구현

## 작업 내용
- Date picker 구현
- 날짜 선택하여 편지 필터링

## 스크린샷
<p align="left">
<img src="https://user-images.githubusercontent.com/88371913/179992931-29123426-ed28-409f-b6b9-6725c89e5ab6.png" width=250>
<img src="https://user-images.githubusercontent.com/88371913/179993071-cabe6ec2-3bfa-4109-a34a-ca08fc6d121e.png" width=250>
</p>

## 주의 사항 
- iPhone13 시뮬레이터 기준으로 컴포넌트 배치하였습니다. 오토 레이아웃 적용하여 수정해야 합니다.
- 임시 데이터 모델을 사용하였습니다.
- 편지를 눌렀을 때 상세 페이지로의 이동은 1차 스프린트 merge 후 추가 예정입니다.

## Reference
[텍스트에서 SF Symbol 사용하기](https://stackoverflow.com/questions/58341042/is-it-possible-to-use-sf-symbols-outside-of-uiimage)