### PR TITLE
[Feat] 메인뷰 타이틀 설정 - 하위뷰 네비게이션 바 뒤로가기 영향

### DIFF
--- a/OverTheRainbow/OverTheRainbow/Screens/mainView/MainViewController.swift
+++ b/OverTheRainbow/OverTheRainbow/Screens/mainView/MainViewController.swift
@@ -24,6 +24,7 @@ class MainViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        title = "홈"
         print("Realm is located at:", realm.configuration.fileURL!)
         quoteLabel.text = (try? service.getWord().content) ?? "DEBUG word 없음"
 


### PR DESCRIPTION
## 개요 
<!-- issue 번호와 개요를 적어주세요. --> 
#3 메인뷰의 title 설정 (하위 뷰 네비게이션 뒤로가기에 영향)

## 작업 내용
<!-- 작업 내용을 적어주세요. --> 
꽃뷰 등 다른 네비게이션으로 연결되는 뷰에서 뒤로가기에 "홈"이 뜨도록 메인뷰의 title 설정

## 주의 사항 
<!-- 주의사항이 있다면 적어주세요 --> 
